### PR TITLE
Ignore host misbehaviour

### DIFF
--- a/include/mostly_harmless/mostlyharmless_Plugin.h
+++ b/include/mostly_harmless/mostlyharmless_Plugin.h
@@ -46,7 +46,7 @@ namespace mostly_harmless {
      * To register your subclassed plugin type with the clap factory, you <b>must</b> call `MOSTLYHARMLESS_REGISTER(YourPluginType)` at the end of your plugin source file.
      */
     template <marvin::FloatType SampleType>
-    class Plugin : public clap::helpers::Plugin<clap::helpers::MisbehaviourHandler::Terminate, clap::helpers::CheckingLevel::Maximal> {
+    class Plugin : public clap::helpers::Plugin<clap::helpers::MisbehaviourHandler::Ignore, clap::helpers::CheckingLevel::Maximal> {
     public:
         /**
          * To establish parameters with the plugin, create a vector of them, and std::move them into the `params` arg here.

--- a/source/mostlyharmless_Plugin.cpp
+++ b/source/mostlyharmless_Plugin.cpp
@@ -7,7 +7,7 @@
 
 namespace mostly_harmless {
     template <marvin::FloatType SampleType>
-    Plugin<SampleType>::Plugin(const clap_host* host, std::vector<Parameter<SampleType>>&& params) : clap::helpers::Plugin<clap::helpers::MisbehaviourHandler::Terminate, clap::helpers::CheckingLevel::Maximal>(&getDescriptor(), host),
+    Plugin<SampleType>::Plugin(const clap_host* host, std::vector<Parameter<SampleType>>&& params) : clap::helpers::Plugin<clap::helpers::MisbehaviourHandler::Ignore, clap::helpers::CheckingLevel::Maximal>(&getDescriptor(), host),
                                                                                                      m_indexedParams(std::move(params)),
                                                                                                      m_procToGuiQueue(1024),
                                                                                                      m_guiToProcQueue(1024) {


### PR DESCRIPTION
For something like Pluginval, designed to ruin your day, it *will* actively call things from the wrong thread - if we terminate on that, we're going to fail pluginval, so....