### PR TITLE
Made `djb2` hash function work with `-Wconversion`

### DIFF
--- a/include/mostly_harmless/utils/mostlyharmless_Hash.h
+++ b/include/mostly_harmless/utils/mostlyharmless_Hash.h
@@ -21,7 +21,7 @@ namespace mostly_harmless::utils {
             auto hash = 5381UL;
             auto* data = toHash.data();
             while (auto c = *data++) {
-                hash = ((hash << 5) + hash) + c;
+                hash = ((hash << 5) + hash) + static_cast<decltype(hash)>(c);
             }
             return static_cast<T>(hash);
         }


### PR DESCRIPTION
When compiling with `-Wconversion`, the old code would error with `-Werror` since the character is signed. Since the minimum character value is -127 and unsigned integer overflow is well defined, this will be consistent https://godbolt.org/z/f7dvqa8Wh